### PR TITLE
Added additional MIME map

### DIFF
--- a/WinCertes/ChallengeValidator/HTTPChallengeFileValidator.cs
+++ b/WinCertes/ChallengeValidator/HTTPChallengeFileValidator.cs
@@ -21,7 +21,9 @@ namespace WinCertes.ChallengeValidator
         {
             _challengeVerifyPath = challengeVerifyPath;
             string webConfig = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<configuration>\n<system.webServer>\n<staticContent>"
-                 + "<mimeMap fileExtension=\".*\" mimeType=\"application/octet-stream\"/>\n</staticContent>\n</system.webServer>\n</configuration>";
+                 + "<mimeMap fileExtension=\".*\" mimeType=\"application/octet-stream\"/>\n"
+                 + "<mimeMap fileExtension=\".\" mimeType=\"application/octet-stream\"/>\n"
+                 + "</staticContent>\n</system.webServer>\n</configuration>";
             try {
                 // First we create necessary directories
                 System.IO.Directory.CreateDirectory($"{_challengeVerifyPath}\\.well-known");


### PR DESCRIPTION
Hi aloopkin,

  Firstly great work on this code it has been really useful.

  For my usage, the default ".*" MIME map placed in the wwwroot did not work.

  However "." did work after searching for a while https://serverfault.com/questions/720043/iis-8-5-serve-file-with-no-extension-from-particular-folder

  I have added the additional mime type to hopefully aid others in future.

Windows Server 2012 R2 Standard
IIS v8.5.9600.16384
