### PR TITLE
fix extra parameter usage

### DIFF
--- a/WinCertes/CertesWrapper.cs
+++ b/WinCertes/CertesWrapper.cs
@@ -51,10 +51,10 @@ namespace WinCertes
         /// </summary>
         /// <param name="serviceUri">The ACME service URI (endin in /directory). If null, defaults to Let's encrypt</param>
         /// <param name="accountEmail">The email address to be registered within the ACME account. If null, no email will be used</param>
-        public CertesWrapper(int extra = -1, string serviceUri = null, string accountEmail = null)
+        public CertesWrapper(RegistryConfig config, string serviceUri = null, string accountEmail = null)
         {
             _settings = new CertesSettings();
-            _config = new RegistryConfig(extra);
+            _config = config;
 
             // Let's initialize the password
             PfxPassword = Guid.NewGuid().ToString("N").Substring(0, 16);

--- a/WinCertes/Config/RegistryConfig.cs
+++ b/WinCertes/Config/RegistryConfig.cs
@@ -9,7 +9,7 @@ namespace WinCertes
     /// <summary>
     /// Configuration class, managing WinCertes configuration into Windows Registry
     /// </summary>
-    class RegistryConfig : IConfig
+    public class RegistryConfig : IConfig
     {
         private static readonly ILogger _logger = LogManager.GetLogger("WinCertes.WinCertesOptions");
 
@@ -53,7 +53,7 @@ namespace WinCertes
                 if (extra > -1)
                 {
                     string extraIndex = "";
-                    if (extra > 1)
+                    if (extra > 0)
                         extraIndex = extra.ToString();
                     if (Registry.LocalMachine.OpenSubKey("SOFTWARE").OpenSubKey("WinCertes").OpenSubKey("extra" + extraIndex) == null)
                     {

--- a/WinCertes/Program.cs
+++ b/WinCertes/Program.cs
@@ -300,10 +300,10 @@ namespace WinCertes
         /// </summary>
         /// <param name="serviceUri">the ACME service URI</param>
         /// <param name="email">the email account used to register</param>
-        private static void InitCertesWrapper(int extra, string serviceUri, string email)
+        private static void InitCertesWrapper(RegistryConfig config, string serviceUri, string email)
         {
             // We get the CertesWrapper object, that will do most of the job.
-            _certesWrapper = new CertesWrapper(extra, serviceUri, email);
+            _certesWrapper = new CertesWrapper(config, serviceUri, email);
 
             // If local computer's account isn't registered on the ACME service, we'll do it.
             if (!_certesWrapper.IsAccountRegistered())
@@ -338,7 +338,8 @@ namespace WinCertes
             if (_periodic) taskName = Utils.DomainsToFriendlyName(_domains);
             InitWinCertesDirectoryPath();
             Utils.ConfigureLogger(_winCertesPath);
-            _config = new RegistryConfig(_extra);
+            var registryConfig = new RegistryConfig(_extra);
+            _config = registryConfig;
             _winCertesOptions.WriteOptionsIntoConfiguration(_config);
             if (_show) { _winCertesOptions.displayOptions(_config); return 0; }
 
@@ -354,7 +355,7 @@ namespace WinCertes
             // Initialization and renewal/revocation handling
             try
             {
-                InitCertesWrapper(_extra, _winCertesOptions.ServiceUri, _winCertesOptions.Email);
+                InitCertesWrapper(registryConfig, _winCertesOptions.ServiceUri, _winCertesOptions.Email);
             }
             catch (Exception e) { _logger.Error(e.Message); return ERROR; }
             if (_winCertesOptions.Revoke > -1) { RevokeCert(_domains, _winCertesOptions.Revoke); return 0; }


### PR DESCRIPTION
due to double invocation of RegistryConfig the static parameter of the name of the registry key was created wrong